### PR TITLE
refactor: remove results from infallibles

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,16 @@ keychain.unlock("my crazy password").unwrap();
 use walleth::Signable
 
 // Create a message to sign
-let message = Signable::from_str("Hello walleth!").unwrap();
+let message = Signable::from_str("Hello walleth!");
 
 // ..and use a signer!
 let signature = keychain.use_signer(account.address, |signer| {
   signer.sign(&message)
-}).unwrap();
+});
 ```
+
+> [!NOTE]
+> See [Keychain documentation page](https://docs.rs/walleth/0.1.0/walleth/account/keychain/keychain/struct.Keychain.html) for more information about the available methods and how to use them.
 
 ### Vault
 
@@ -85,11 +88,11 @@ vault.unlock(b"my secret password").unwrap();
 
 use walleth::Signable;
 
-let message = Signable::from_str("Hello walleth!").unwrap();
+let message = Signable::from_str("Hello walleth!");
 
 // Use a signer from the vault
 vault.use_signer(0, |signer| {
- signer.sign(&[0; 32])
+ signer.sign(&message)
 });
 ```
 
@@ -139,7 +142,7 @@ let hdwallet = HDWallet::new();
 let hdwallet = HDWallet::::from_mnemonic_str("grocery belt target explain clay essay focus spatial skull brain measure matrix toward visual protect owner stone scale slim ghost panda exact combine game").unwrap();
 
 // Derive private key at path m'/60'/0'/0'/0
-let private_key = hdwallet.private_key_at_path(0, 0, 0);
+let private_key = hdwallet.private_key_at_path(0, 0, 0).unwrap();
 ```
 
 > [!NOTE]

--- a/src/account/keychain/keychain.rs
+++ b/src/account/keychain/keychain.rs
@@ -87,7 +87,7 @@ impl Keychain {
 	///
 	/// let mut keychain = Keychain::new();
 	/// let key = keychain.add_account().unwrap();
-	/// let message = Signable::from_str("Hello world!").unwrap();
+	/// let message = Signable::from_str("Hello world!");
 	///
 	/// let signature = keychain.use_signer(key.address, |signer| {
 	///   signer.sign(&message)

--- a/src/account/signer/signer.rs
+++ b/src/account/signer/signer.rs
@@ -15,7 +15,7 @@ use crate::Signable;
 ///
 /// let signer = Signer::new(private_key.to_bytes());
 /// assert!(signer.is_ok());
-/// 
+///
 /// let signature = signer.unwrap().sign(&message);
 /// ```
 pub struct Signer {

--- a/src/account/signer/signer.rs
+++ b/src/account/signer/signer.rs
@@ -10,14 +10,13 @@ use crate::Signable;
 /// ```
 /// use walleth::{Signer, Signable, HDWallet};
 ///
-/// let hdwallet = HDWallet::new();
-/// let private_key = hdwallet.private_key_at_path(0, 0, 0).unwrap();
+/// let private_key = HDWallet::new().private_key_at_path(0, 0, 0).unwrap();
+/// let message = Signable::new(&[0; 32]);
 ///
-/// let signer = Signer::new(private_key).unwrap();
-/// let message = Signable::new(&[0; 32]).unwrap();
-/// let signature = signer.sign(&message);
-///
-/// assert!(signature.is_ok());
+/// let signer = Signer::new(private_key.to_bytes());
+/// assert!(signer.is_ok());
+/// 
+/// let signature = signer.unwrap().sign(&message);
 /// ```
 pub struct Signer {
 	/// The secret key, derived from a private key
@@ -25,7 +24,7 @@ pub struct Signer {
 }
 
 impl Signer {
-	/// Create a new signer from a private key
+	/// Create a new signer from a private key bytes
 	///
 	/// # Example
 	///
@@ -35,7 +34,7 @@ impl Signer {
 	/// let hdwallet = HDWallet::new();
 	/// let private_key = hdwallet.private_key_at_path(0, 0, 0).unwrap();
 	///
-	/// let signer = Signer::new(private_key);
+	/// let signer = Signer::new(private_key.to_bytes());
 	///
 	/// assert!(signer.is_ok());
 	/// ```
@@ -55,15 +54,13 @@ impl Signer {
 	///
 	/// let hdwallet = HDWallet::new();
 	/// let private_key = hdwallet.private_key_at_path(0, 0, 0).unwrap();
-	/// let signer = Signer::new(private_key).unwrap();
-	/// let message = Signable::new(&[0; 32]).unwrap();
+	/// let signer = Signer::new(private_key.to_bytes()).unwrap();
+	/// let message = Signable::new(&[0; 32]);
 	///
 	/// let signature = signer.sign(&message);
-	///
-	/// assert!(signature.is_ok());
 	/// ```
-	pub fn sign(&self, signable: &Signable) -> Result<Signature, String> {
-		Ok(Secp256k1::new().sign_ecdsa(&signable.to_signable_message(), &self.secret_key))
+	pub fn sign(&self, signable: &Signable) -> Signature {
+		Secp256k1::new().sign_ecdsa(&signable.to_signable_message(), &self.secret_key)
 	}
 }
 
@@ -78,7 +75,7 @@ impl Signer {
 /// let hdwallet = HDWallet::new();
 /// let private_key = hdwallet.private_key_at_path(0, 0, 0).unwrap();
 ///
-/// let secret_key = get_secret_key_from_bytes(&private_key);
+/// let secret_key = get_secret_key_from_bytes(private_key.to_bytes());
 ///
 /// assert!(secret_key.is_ok());
 /// ```

--- a/src/account/vault/vault.rs
+++ b/src/account/vault/vault.rs
@@ -29,7 +29,7 @@ use crate::{signer::Signer, Account, EncryptionKey, HDWallet, Safe};
 ///
 /// // Use a signer from the vault
 /// let signature = vault.use_signer(0, |signer| {
-///  signer.sign(&Signable::from_str("Hello world!").unwrap())
+///  signer.sign(&Signable::from_str("Hello world!"))
 /// });
 ///
 /// assert!(signature.is_ok());
@@ -135,7 +135,7 @@ impl Vault {
 	/// use walleth::{Vault, Signable};
 	///
 	/// let mut vault = Vault::new();
-	/// let message = Signable::from_str("Hello world!").unwrap();
+	/// let message = Signable::from_str("Hello world!");
 	/// vault.add_key().unwrap();
 	///
 	/// let signature = vault.use_signer(0, |signer| {

--- a/tests/keychain.rs
+++ b/tests/keychain.rs
@@ -68,7 +68,7 @@ mod use_signer {
 		let message = Signable::from_bytes(b"Hello world!");
 
 		let signature = keychain
-			.use_signer(key.address, |signer| signer.sign(&message).unwrap())
+			.use_signer(key.address, |signer| signer.sign(&message))
 			.unwrap();
 
 		assert!(Secp256k1::new()


### PR DESCRIPTION
This PR removes `Result` enums from some methods as they are infallible