### PR TITLE
test: use cargo test as docs will also be tested

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -34,11 +34,5 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install llvm-tools-preview
-      run: rustup component add llvm-tools-preview
-
-    - name: Install cargo-llvm-cov
-      run: cargo install cargo-llvm-cov
-
-    - name: Run test with coverage
-      run: cargo llvm-cov --verbose
+    - name: Text
+      run: cargo test


### PR DESCRIPTION
This PR changes the command used by CI for testing, as `cargo test` also tests documentation, which is nice!