### PR TITLE
test: fix lint step

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -24,8 +24,9 @@ jobs:
 
     - name: Lint
       run: |
-        if ! rustfmt --check ./src/*.rs; then
-          echo "Please run 'rustfmt' to format your code."
+        rustfmt ./**/*.rs
+        if ! git diff --exit-code; then
+          echo "Please run 'rustfmt --check ./**/*.rs' to lint your code."
           exit 1
         fi
   


### PR DESCRIPTION
Fixing lint step to check `rustfmt` also for `tests` folder