### PR TITLE
feat: backup and restore keychain

### DIFF
--- a/src/keychain/keychain.rs
+++ b/src/keychain/keychain.rs
@@ -167,17 +167,17 @@ impl Keychain {
   }
 
   /// Backup the keychain
-  /// 
+  ///
   /// # Example
-  /// 
+  ///
   /// ```
   /// use walleth::Keychain;
-  /// 
+  ///
   /// let mut keychain = Keychain::new();
   /// let account = keychain.add_account().unwrap();
-  /// 
+  ///
   /// let backup = keychain.backup("password").unwrap();
-  /// 
+  ///
   /// assert!(backup.len() > 0);
   /// ```
   pub fn backup(&mut self, password: &str) -> Result<Vec<u8>, KeychainError> {
@@ -193,18 +193,18 @@ impl Keychain {
   }
 
   /// Restore a keychain from a backup
-  /// 
+  ///
   /// # Example
-  /// 
+  ///
   /// ```
   /// use walleth::Keychain;
-  /// 
+  ///
   /// let mut keychain = Keychain::new();
   /// let account = keychain.add_account().unwrap();
   /// let backup = keychain.backup("password").unwrap();
-  /// 
+  ///
   /// let restored_keychain = Keychain::restore(backup, "password").unwrap();
-  /// 
+  ///
   /// assert_eq!(keychain, restored_keychain);
   /// ```
   pub fn restore(bytes: Vec<u8>, password: &str) -> Result<Self, KeychainError> {
@@ -212,7 +212,7 @@ impl Keychain {
       vault: Vault::try_from(bytes)?,
       store: Observable::new(KeychainState { accounts: vec![] }),
     };
-    
+
     keychain.unlock(password)?;
 
     Ok(keychain)

--- a/src/keychain/keychain.rs
+++ b/src/keychain/keychain.rs
@@ -15,7 +15,7 @@ pub struct KeychainState {
 /// A `Keychain` is a collection of accounts with signing capabilities
 /// It is backed by an encrypted vault which holds the mnemonic
 /// and some metadata for generated accounts.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Keychain {
   /// The vault
   vault: Vault,
@@ -164,6 +164,58 @@ impl Keychain {
     })?;
 
     Ok(&self.store.get_state().accounts)
+  }
+
+  /// Backup the keychain
+  /// 
+  /// # Example
+  /// 
+  /// ```
+  /// use walleth::Keychain;
+  /// 
+  /// let mut keychain = Keychain::new();
+  /// let account = keychain.add_account().unwrap();
+  /// 
+  /// let backup = keychain.backup("password").unwrap();
+  /// 
+  /// assert!(backup.len() > 0);
+  /// ```
+  pub fn backup(&mut self, password: &str) -> Result<Vec<u8>, KeychainError> {
+    if self.vault.is_unlocked() {
+      self.lock(password)?;
+      let bytes = self.vault.to_bytes()?;
+      self.unlock(password)?;
+
+      return Ok(bytes);
+    }
+
+    Ok(self.vault.to_bytes()?)
+  }
+
+  /// Restore a keychain from a backup
+  /// 
+  /// # Example
+  /// 
+  /// ```
+  /// use walleth::Keychain;
+  /// 
+  /// let mut keychain = Keychain::new();
+  /// let account = keychain.add_account().unwrap();
+  /// let backup = keychain.backup("password").unwrap();
+  /// 
+  /// let restored_keychain = Keychain::restore(backup, "password").unwrap();
+  /// 
+  /// assert_eq!(keychain, restored_keychain);
+  /// ```
+  pub fn restore(bytes: Vec<u8>, password: &str) -> Result<Self, KeychainError> {
+    let mut keychain = Keychain {
+      vault: Vault::try_from(bytes)?,
+      store: Observable::new(KeychainState { accounts: vec![] }),
+    };
+    
+    keychain.unlock(password)?;
+
+    Ok(keychain)
   }
 }
 

--- a/src/keychain/vault/errors.rs
+++ b/src/keychain/vault/errors.rs
@@ -1,32 +1,40 @@
 use std::{error::Error, fmt::Display};
 
-use crate::{AccountError, SignerError};
+use crate::{AccountError, SignerError, SafeError};
 
 #[derive(Debug)]
 pub enum VaultError {
   ForbiddenWhileLocked,
+  ForbiddenWhileUnlocked,
   AccountCreation,
   InvalidPassword,
   InvalidMnemonic,
   SignerCreation,
   KeyDerivation,
   AlreadyUnlocked,
+  VaultRestoreFromBytes(String),
   SafeCreation,
   SafeDecrypt,
+  SafeExport,
+  SafeRestore,
 }
 
 impl Display for VaultError {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
       Self::ForbiddenWhileLocked => write!(f, "Forbidden while locked"),
+      Self::ForbiddenWhileUnlocked => write!(f, "Forbidden while unlocked"),
       Self::AccountCreation => write!(f, "Account creation error"),
       Self::InvalidPassword => write!(f, "Invalid password"),
       Self::InvalidMnemonic => write!(f, "Invalid mnemonic"),
       Self::SignerCreation => write!(f, "Signer creation error"),
       Self::KeyDerivation => write!(f, "Key derivation error"),
       Self::AlreadyUnlocked => write!(f, "Already unlocked"),
+      Self::VaultRestoreFromBytes(message) => write!(f, "Vault restore from bytes error: {}", message),
       Self::SafeCreation => write!(f, "Safe creation error"),
       Self::SafeDecrypt => write!(f, "Safe decryption error"),
+      Self::SafeExport => write!(f, "Safe export error"),
+      Self::SafeRestore => write!(f, "Safe restore error"),
     }
   }
 }
@@ -40,6 +48,15 @@ impl From<AccountError> for VaultError {
 impl From<SignerError> for VaultError {
   fn from(_: SignerError) -> Self {
     Self::SignerCreation
+  }
+}
+
+impl From<SafeError> for VaultError {
+  fn from(error: SafeError) -> Self {
+    match error {
+      SafeError::Serialization => Self::SafeExport,
+      SafeError::Deserialization => Self::SafeRestore,
+    }
   }
 }
 

--- a/src/keychain/vault/errors.rs
+++ b/src/keychain/vault/errors.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, fmt::Display};
 
-use crate::{AccountError, SignerError, SafeError};
+use crate::{AccountError, SafeError, SignerError};
 
 #[derive(Debug)]
 pub enum VaultError {
@@ -30,7 +30,9 @@ impl Display for VaultError {
       Self::SignerCreation => write!(f, "Signer creation error"),
       Self::KeyDerivation => write!(f, "Key derivation error"),
       Self::AlreadyUnlocked => write!(f, "Already unlocked"),
-      Self::VaultRestoreFromBytes(message) => write!(f, "Vault restore from bytes error: {}", message),
+      Self::VaultRestoreFromBytes(message) => {
+        write!(f, "Vault restore from bytes error: {}", message)
+      }
       Self::SafeCreation => write!(f, "Safe creation error"),
       Self::SafeDecrypt => write!(f, "Safe decryption error"),
       Self::SafeExport => write!(f, "Safe export error"),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,4 +8,4 @@ pub mod safe;
 pub use controller::Controller;
 pub use hdwallet::*;
 pub use observable::{Observable, Observer};
-pub use safe::*;
+pub use safe::{ChaCha20Poly1305Cipher, CipherKey, CipherNonce, EncryptionKey, Safe, SafeError};

--- a/src/utils/observable/observable.rs
+++ b/src/utils/observable/observable.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use super::{ObservableError, Observer};
 
 /// A store for state that can be subscribed to
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Observable<S> {
   state: S,
   observers: Vec<Observer<S>>,

--- a/src/utils/observable/observer.rs
+++ b/src/utils/observable/observer.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::{sync::{Arc, Mutex}, fmt::{Debug, Formatter, Result}};
 
 type Listener<T> = dyn FnMut(&T) -> ();
 
@@ -14,5 +14,11 @@ impl<S> Observer<S> {
       id,
       callback: callback,
     }
+  }
+}
+
+impl<S> Debug for Observer<S> {
+  fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    write!(f, "Observer {{ id: {} }}", self.id)
   }
 }

--- a/src/utils/observable/observer.rs
+++ b/src/utils/observable/observer.rs
@@ -1,4 +1,7 @@
-use std::{sync::{Arc, Mutex}, fmt::{Debug, Formatter, Result}};
+use std::{
+  fmt::{Debug, Formatter, Result},
+  sync::{Arc, Mutex},
+};
 
 type Listener<T> = dyn FnMut(&T) -> ();
 

--- a/src/utils/safe/errors.rs
+++ b/src/utils/safe/errors.rs
@@ -1,0 +1,15 @@
+use std::fmt::{Display, Formatter, Result};
+
+pub enum SafeError {
+  Serialization,
+  Deserialization,
+}
+
+impl Display for SafeError {
+  fn fmt(&self, f: &mut Formatter) -> Result {
+    match self {
+      SafeError::Serialization => write!(f, "Unable to serialize safe"),
+      SafeError::Deserialization => write!(f, "Unable to deserialize safe"),
+    }
+  }
+}

--- a/src/utils/safe/mod.rs
+++ b/src/utils/safe/mod.rs
@@ -1,9 +1,9 @@
 pub mod cipher;
 pub mod encryption_key;
-pub mod safe;
 pub mod errors;
+pub mod safe;
 
 pub use cipher::{ChaCha20Poly1305Cipher, CipherKey, CipherNonce};
 pub use encryption_key::EncryptionKey;
-pub use safe::Safe;
 pub use errors::SafeError;
+pub use safe::Safe;

--- a/src/utils/safe/mod.rs
+++ b/src/utils/safe/mod.rs
@@ -1,7 +1,9 @@
 pub mod cipher;
 pub mod encryption_key;
 pub mod safe;
+pub mod errors;
 
 pub use cipher::{ChaCha20Poly1305Cipher, CipherKey, CipherNonce};
 pub use encryption_key::EncryptionKey;
 pub use safe::Safe;
+pub use errors::SafeError;

--- a/tests/keychain.rs
+++ b/tests/keychain.rs
@@ -118,7 +118,7 @@ mod recover {
     keychain.add_account().unwrap();
     let backup = keychain.backup("password").unwrap();
 
-    let recovered= Keychain::restore(backup, "password").unwrap();
+    let recovered = Keychain::restore(backup, "password").unwrap();
 
     assert_eq!(recovered, keychain);
   }

--- a/tests/keychain.rs
+++ b/tests/keychain.rs
@@ -109,6 +109,21 @@ mod unlock {
   }
 }
 
+mod recover {
+  use super::*;
+
+  #[test]
+  fn it_recovers_the_keychain() {
+    let mut keychain = Keychain::new();
+    keychain.add_account().unwrap();
+    let backup = keychain.backup("password").unwrap();
+
+    let recovered= Keychain::restore(backup, "password").unwrap();
+
+    assert_eq!(recovered, keychain);
+  }
+}
+
 mod update {
 
   use super::*;


### PR DESCRIPTION
Add pub methods to Keychain, Vault, and Sage implementations to export and restore from/to a `u8` array, making it easy to save it or send it anywhere. 